### PR TITLE
bugfix: false convergence BUT not close to boundaries

### DIFF
--- a/fireSense_IgnitionFit.R
+++ b/fireSense_IgnitionFit.R
@@ -161,7 +161,7 @@ doEvent.fireSense_IgnitionFit = function(sim, eventTime, eventType, debug = FALS
                   "' in module '", current(sim)[1, "moduleName", with = FALSE], "'", sep = ""))
   )
 
-  invisible(sim)
+  return(invisible(sim))
 }
 
 ## event functions

--- a/fireSense_IgnitionFit.R
+++ b/fireSense_IgnitionFit.R
@@ -900,8 +900,12 @@ frequencyFitRun <- function(sim) {
     closeToBoundsOnlyCovariates <- closeToBounds[1:nx]
     # This only has terms with covariates (including pw in interaction), not pw terms on their own
     possTerms <- attr(terms, "term.labels")[1:nx]
-    toRemove <- do.call(rbind, lapply(ctb$term, function(trm) grepl(trm, possTerms)))
-    toRemove <- apply(toRemove, 2, any)
+    if (nrow(ctb)) {
+      toRemove <- do.call(rbind, lapply(ctb$term, function(trm) grepl(trm, possTerms)))
+      toRemove <- apply(toRemove, 2, any)
+    } else {
+      toRemove <- sapply(closeToBoundsOnlyCovariates, function(x) FALSE)
+    }
     toRemove <- toRemove | closeToBoundsOnlyCovariates
 
     possTerms <- possTerms[!toRemove]


### PR DESCRIPTION
I'm my last LIM sims I've hit false convergence, but estimated coefficients were not close to boundaris.
This caused the `ctb` table to be empty (no covariates close to boundaries) and `toRemove` becoming `NULL`, which led to failure during the`apply(toRemove, 2, any)` call.

I propose a fix that detects whether `ctb` is an empty table first.