### PR TITLE
Fix plot bugs: variable rescaling and tryCatch(`Plots`)

### DIFF
--- a/fireSense_IgnitionFit.R
+++ b/fireSense_IgnitionFit.R
@@ -854,13 +854,11 @@ frequencyFitRun <- function(sim) {
     labelToUse <- paste0("Ignition rate per ", resInKm2, "km2")
     filenameToUse <- paste0("IgnitionRatePer", resInKm2)
 
-    ## TODO: Ceres: added the try workaround bc Plots is erroring inn this line `sim@outputs <- outputsAppend ...`
-    tryCatch(Plots(data = ndLong, fn = pwPlot, xColName = colName,
+    Plots(data = ndLong, fn = pwPlot, xColName = colName,
                    ggylab = labelToUse,
                    origXmax = max(sim$fireSense_ignitionCovariates[[colName]]), #if supplied, adds bar to plot
                    ggTitle =  paste0(basename(outputPath(sim)), " fireSense IgnitionFit"),
-                   filename = filenameToUse),
-             error = function(e) print(e))#, types = "screen", .plotInitialTime = time(sim))
+                   filename = filenameToUse) #, types = "screen", .plotInitialTime = time(sim))
     #TODO: unresolved bug in Plot triggered by spaces
 
     ## FITTED VS OBSERVED VALUES
@@ -899,13 +897,11 @@ frequencyFitRun <- function(sim) {
     plotData[, predFires := as.integer(predFires)]
     plotData <- melt(plotData, id.var = c(xvar, "n"))
 
-    ## TODO: Ceres: added the try workaround bc Plots is erroring inn this line `sim@outputs <- outputsAppend ...`
-    tryCatch(Plots(data = plotData, fn = fittedVsObservedPlot,
+    Plots(data = plotData, fn = fittedVsObservedPlot,
                    xColName = xvar,
                    ggylab = "no. fires",
                    ggTitle =  paste0(basename(outputPath(sim)), " fireSense IgnitionFit observed vs. fitted values"),
-                   filename = "ignitionNoFiresFitted"),
-             error = function(e) print(e))
+                   filename = "ignitionNoFiresFitted")
   }
 
   convergence <- TRUE

--- a/fireSense_IgnitionFit.R
+++ b/fireSense_IgnitionFit.R
@@ -724,9 +724,13 @@ frequencyFitRun <- function(sim) {
 
       if (trace) parallel::clusterEvalQ(cl, sink())
     } else {
+      ## TODO: Ceres, I have tested the results in parallel mode with 1 core and using lapply with
+      ## LIM data. The results are identical, despite the lapply option printing the error message (not for every start pop, though):
+      # Error in optim(par = x, fn = objective, lower = lower, upper = upper,  :
+      #                  L-BFGS-B needs finite values of 'fn'
       warning("This is not tested by Eliot as of March 4, 2021; please set parameter: cores > 1")
       if (hvPW) {
-        out <- Cache(lapply, start[1], objNlminb, objective = objfun, lower = nlminbLB, upper = nlminbUB, hvPW = hvPW,
+        out <- Cache(lapply, start, objNlminb, objective = objfun, lower = nlminbLB, upper = nlminbUB, hvPW = hvPW,
                      linkinv = linkinv, nll = nll, sm = sm, nx = nx, mm = mm, #TODO mm may not be required with PW...
                      mod_env = fireSense_ignitionCovariates, offset = offset,
                      formula = P(sim)$fireSense_ignitionFormula,
@@ -735,7 +739,7 @@ frequencyFitRun <- function(sim) {
                      omitArgs = c("X", "userTags"),
                      control = c(P(sim)$nlminb.control, list(trace = min(6, trace * 3))))
       } else {
-        out <- Cache(lapply, start[1], objNlminb, objective = objfun, lower = nlminbLB, upper = nlminbUB, hvPW = hvPW,
+        out <- Cache(lapply, start, objNlminb, objective = objfun, lower = nlminbLB, upper = nlminbUB, hvPW = hvPW,
                      linkinv = linkinv, nll = nll, sm = sm, nx = nx, mm = mm, #TODO mm may not be required with PW...
                      mod_env = fireSense_ignitionCovariates, offset = offset,
                      userTags = c(currentModule(sim), "objNlminb"),

--- a/fireSense_IgnitionFit.R
+++ b/fireSense_IgnitionFit.R
@@ -161,7 +161,7 @@ doEvent.fireSense_IgnitionFit = function(sim, eventTime, eventType, debug = FALS
                   "' in module '", current(sim)[1, "moduleName", with = FALSE], "'", sep = ""))
   )
 
-  invisible(sim)
+  return(invisible(sim))
 }
 
 ## event functions

--- a/fireSense_IgnitionFit.R
+++ b/fireSense_IgnitionFit.R
@@ -853,11 +853,14 @@ frequencyFitRun <- function(sim) {
     resInKm2 <- round(raster::res(sim$ignitionFitRTM)[1]^2/1e6) #1e6 m2 in km2
     labelToUse <- paste0("Ignition rate per ", resInKm2, "km2")
     filenameToUse <- paste0("IgnitionRatePer", resInKm2)
-    Plots(data = ndLong, fn = pwPlot, xColName = colName,
-          ggylab = labelToUse,
-          origXmax = max(sim$fireSense_ignitionCovariates[[colName]]), #if supplied, adds bar to plot
-          ggTitle =  paste0(basename(outputPath(sim)), " fireSense IgnitionFit"),
-          filename = filenameToUse)#, types = "screen", .plotInitialTime = time(sim))
+
+    ## TODO: Ceres: added the try workaround bc Plots is erroring inn this line `sim@outputs <- outputsAppend ...`
+    tryCatch(Plots(data = ndLong, fn = pwPlot, xColName = colName,
+                   ggylab = labelToUse,
+                   origXmax = max(sim$fireSense_ignitionCovariates[[colName]]), #if supplied, adds bar to plot
+                   ggTitle =  paste0(basename(outputPath(sim)), " fireSense IgnitionFit"),
+                   filename = filenameToUse),
+             error = function(e) print(e))#, types = "screen", .plotInitialTime = time(sim))
     #TODO: unresolved bug in Plot triggered by spaces
 
     ## FITTED VS OBSERVED VALUES
@@ -896,11 +899,13 @@ frequencyFitRun <- function(sim) {
     plotData[, predFires := as.integer(predFires)]
     plotData <- melt(plotData, id.var = c(xvar, "n"))
 
-    Plots(data = plotData, fn = fittedVsObservedPlot,
-          xColName = xvar,
-          ggylab = "no. fires",
-          ggTitle =  paste0(basename(outputPath(sim)), " fireSense IgnitionFit observed vs. fitted values"),
-          filename = "ignitionNoFiresFitted")
+    ## TODO: Ceres: added the try workaround bc Plots is erroring inn this line `sim@outputs <- outputsAppend ...`
+    tryCatch(Plots(data = plotData, fn = fittedVsObservedPlot,
+                   xColName = xvar,
+                   ggylab = "no. fires",
+                   ggTitle =  paste0(basename(outputPath(sim)), " fireSense IgnitionFit observed vs. fitted values"),
+                   filename = "ignitionNoFiresFitted"),
+             error = function(e) print(e))
   }
 
   convergence <- TRUE

--- a/fireSense_IgnitionFit.R
+++ b/fireSense_IgnitionFit.R
@@ -900,8 +900,12 @@ frequencyFitRun <- function(sim) {
     closeToBoundsOnlyCovariates <- closeToBounds[1:nx]
     # This only has terms with covariates (including pw in interaction), not pw terms on their own
     possTerms <- attr(terms, "term.labels")[1:nx]
-    toRemove <- do.call(rbind, lapply(ctb$term, function(trm) grepl(trm, possTerms)))
-    toRemove <- apply(toRemove, 2, any)
+    if (nrow(ctb)) {
+      toRemove <- do.call(rbind, lapply(ctb$term, function(trm) grepl(trm, possTerms)))
+      toRemove <- apply(toRemove, 2, any)
+    } else {
+      toRemove <- sapply(closeToBoundsOnlyCovariates, function(x) FALSE)
+    }
     toRemove <- toRemove | closeToBoundsOnlyCovariates
 
     possTerms <- possTerms[!toRemove]


### PR DESCRIPTION
* Rescaled variables were not being properly restored to their original scale
* `Plots` has an internal error after saving figures see https://github.com/PredictiveEcology/SpaDES.core/issues/204. A `tryCatch` was put in place to prevent failure