### PR TITLE
Fix plot bugs: variable rescaling and tryCatch(Plots) (revamp of #18)

### DIFF
--- a/fireSense_IgnitionFit.R
+++ b/fireSense_IgnitionFit.R
@@ -849,11 +849,14 @@ frequencyFitRun <- function(sim) {
     resInKm2 <- round(raster::res(sim$ignitionFitRTM)[1]^2/1e6) #1e6 m2 in km2
     labelToUse <- paste0("Ignition rate per ", resInKm2, "km2")
     filenameToUse <- paste0("IgnitionRatePer", resInKm2)
-    Plots(data = ndLong, fn = pwPlot, xColName = colName,
-          ggylab = labelToUse,
-          origXmax = max(sim$fireSense_ignitionCovariates[[colName]]), #if supplied, adds bar to plot
-          ggTitle =  paste0(basename(outputPath(sim)), " fireSense IgnitionFit"),
-          filename = filenameToUse)#, types = "screen", .plotInitialTime = time(sim))
+
+    ## TODO: Ceres: added the try workaround bc Plots is erroring inn this line `sim@outputs <- outputsAppend ...`
+    tryCatch(Plots(data = ndLong, fn = pwPlot, xColName = colName,
+                   ggylab = labelToUse,
+                   origXmax = max(sim$fireSense_ignitionCovariates[[colName]]), #if supplied, adds bar to plot
+                   ggTitle =  paste0(basename(outputPath(sim)), " fireSense IgnitionFit"),
+                   filename = filenameToUse),
+             error = function(e) print(e))#, types = "screen", .plotInitialTime = time(sim))
     #TODO: unresolved bug in Plot triggered by spaces
 
     ## FITTED VS OBSERVED VALUES
@@ -892,11 +895,13 @@ frequencyFitRun <- function(sim) {
     plotData[, predFires := as.integer(predFires)]
     plotData <- melt(plotData, id.var = c(xvar, "n"))
 
-    Plots(data = plotData, fn = fittedVsObservedPlot,
-          xColName = xvar,
-          ggylab = "no. fires",
-          ggTitle =  paste0(basename(outputPath(sim)), " fireSense IgnitionFit observed vs. fitted values"),
-          filename = "ignitionNoFiresFitted")
+    ## TODO: Ceres: added the try workaround bc Plots is erroring inn this line `sim@outputs <- outputsAppend ...`
+    tryCatch(Plots(data = plotData, fn = fittedVsObservedPlot,
+                   xColName = xvar,
+                   ggylab = "no. fires",
+                   ggTitle =  paste0(basename(outputPath(sim)), " fireSense IgnitionFit observed vs. fitted values"),
+                   filename = "ignitionNoFiresFitted"),
+             error = function(e) print(e))
   }
 
   convergence <- TRUE

--- a/fireSense_IgnitionFit.R
+++ b/fireSense_IgnitionFit.R
@@ -842,6 +842,7 @@ frequencyFitRun <- function(sim) {
                          linkinv = linkinv,
                          rescaler = mod$rescales,
                          rescaleVar = P(sim)$rescaleVars,
+                         covMinMax_ignition = sim$covMinMax_ignition,
                          xCeiling = xCeiling)
 
     #round to avoid silly decimal errors
@@ -1050,7 +1051,8 @@ pwPlot <- function(d, ggTitle, ggylab, xColName, origXmax = NULL)  {
 }
 
 pwPlotData <- function(bestParams, formula, xColName = "MDC", nx, offset, linkinv,
-                       solvedHess, ses, rescaler, rescaleVar, xCeiling = NULL) {
+                       solvedHess, ses, rescaler, rescaleVar, xCeiling = NULL,
+                       covMinMax_ignition = sim$covMinMax_ignition) {
   cns <- rownames(attr(terms(as.formula(formula)), "factors"))[-1]
   cns <- setdiff(cns, xColName)
   cns <- grep("pw\\(", cns, value = TRUE, invert = TRUE)
@@ -1099,10 +1101,16 @@ pwPlotData <- function(bestParams, formula, xColName = "MDC", nx, offset, linkin
     if (!is.null(rescaler)) {
       toBeScaled <- xColName[xColName %in% names(rescaler)]
       for (cn in toBeScaled) {
-        newDat[, eval(cn) := get(cn) * rescaler[cn]]
+        if (grepl("rescale", rescaler[[cn]])) {
+          cmm <- covMinMax_ignition[[cn]]
+          newDat[, eval(cn) := LandR::rescale(get(cn), to = c(min(cmm), max(cmm)))]
+        } else {
+          ## TO DO. if users past custom scaling functions, back transforming may be tricky
+        }
       }
     }
   }
+
   newDat[, `:=`(lci  = lci, uci = uci)]
 
   if (!is.null(xCeiling)) {

--- a/fireSense_IgnitionFit.R
+++ b/fireSense_IgnitionFit.R
@@ -161,7 +161,7 @@ doEvent.fireSense_IgnitionFit = function(sim, eventTime, eventType, debug = FALS
                   "' in module '", current(sim)[1, "moduleName", with = FALSE], "'", sep = ""))
   )
 
-  invisible(sim)
+  return(invisible(sim))
 }
 
 ## event functions

--- a/fireSense_IgnitionFit.R
+++ b/fireSense_IgnitionFit.R
@@ -301,6 +301,21 @@ frequencyFitRun <- function(sim) {
     sim$covMinMax_ignition <- NULL
   }
 
+  ## save for later
+  mod$rescales <- if (P(sim)$rescaleVars) {
+    if (is.null(P(sim)$rescalers)) {
+      sapply(needRescale, FUN = function(x){
+        paste0("LandR::rescale(", x, ", to = c(0,1))")
+      }, USE.NAMES = TRUE, simplify = FALSE)
+    } else {
+      sapply(names(P(sim)$rescalers), FUN = function(x, vec) {
+        paste(x, "/", vec[x])
+      }, vec = P(sim)$rescalers, USE.NAMES = TRUE, simplify = FALSE)
+    }
+  } else {
+    NULL
+  }
+
   # sim$fireSense_ignitionFormula <- paste0("ignitions ~ ",
   #                                         # "youngAge:MDC + ",
   #                                         "nonForest_highFlam:MDC + ",
@@ -825,7 +840,7 @@ frequencyFitRun <- function(sim) {
                          formula = P(sim)$fireSense_ignitionFormula,
                          xColName = colName, nx = nx, offset = offset,
                          linkinv = linkinv,
-                         rescaler = P(sim)$rescalers,
+                         rescaler = mod$rescales,
                          rescaleVar = P(sim)$rescaleVars,
                          xCeiling = xCeiling)
 
@@ -967,20 +982,6 @@ frequencyFitRun <- function(sim) {
   ## Parameters scaling: Revert back estimated coefficients to their original scale
   outBest$par <- drop(outBest$par %*% sm)
 
-  rescales <- if (P(sim)$rescaleVars) {
-    if (is.null(P(sim)$rescalers)) {
-      sapply(needRescale, FUN = function(x){
-        paste0("LandR::rescale(", x, ", to = c(0,1))")
-      }, USE.NAMES = TRUE, simplify = FALSE)
-    } else {
-      sapply(names(P(sim)$rescalers), FUN = function(x, vec) {
-        paste(x, "/", vec[x])
-      }, vec = P(sim)$rescalers, USE.NAMES = TRUE, simplify = FALSE)
-    }
-  } else {
-    rescales <- NULL
-  }
-
   ## TODO: added raster attributes may not be ideal to track number of non-NAs
   ## rationale for lambdaRescaleFactor:
   ## original fire prob is sum(n_fires)/nrow(preSampleData),
@@ -999,7 +1000,7 @@ frequencyFitRun <- function(sim) {
             AIC = 2 * length(outBest$par) + 2 * outBest$objective,
             convergence = convergence,
             convergenceDiagnostic = convergDiagnostic,
-            rescales = rescales,
+            rescales = mod$rescales,
             fittingRes = raster::res(sim$ignitionFitRTM)[1],  ## TODO: this assumes square pixels, is this okay?
             lambdaRescaleFactor = lambdaRescaleFactor)
 

--- a/fireSense_IgnitionFit.R
+++ b/fireSense_IgnitionFit.R
@@ -850,13 +850,11 @@ frequencyFitRun <- function(sim) {
     labelToUse <- paste0("Ignition rate per ", resInKm2, "km2")
     filenameToUse <- paste0("IgnitionRatePer", resInKm2)
 
-    ## TODO: Ceres: added the try workaround bc Plots is erroring inn this line `sim@outputs <- outputsAppend ...`
-    tryCatch(Plots(data = ndLong, fn = pwPlot, xColName = colName,
+    Plots(data = ndLong, fn = pwPlot, xColName = colName,
                    ggylab = labelToUse,
                    origXmax = max(sim$fireSense_ignitionCovariates[[colName]]), #if supplied, adds bar to plot
                    ggTitle =  paste0(basename(outputPath(sim)), " fireSense IgnitionFit"),
-                   filename = filenameToUse),
-             error = function(e) print(e))#, types = "screen", .plotInitialTime = time(sim))
+                   filename = filenameToUse) #, types = "screen", .plotInitialTime = time(sim))
     #TODO: unresolved bug in Plot triggered by spaces
 
     ## FITTED VS OBSERVED VALUES
@@ -895,13 +893,11 @@ frequencyFitRun <- function(sim) {
     plotData[, predFires := as.integer(predFires)]
     plotData <- melt(plotData, id.var = c(xvar, "n"))
 
-    ## TODO: Ceres: added the try workaround bc Plots is erroring inn this line `sim@outputs <- outputsAppend ...`
-    tryCatch(Plots(data = plotData, fn = fittedVsObservedPlot,
+    Plots(data = plotData, fn = fittedVsObservedPlot,
                    xColName = xvar,
                    ggylab = "no. fires",
                    ggTitle =  paste0(basename(outputPath(sim)), " fireSense IgnitionFit observed vs. fitted values"),
-                   filename = "ignitionNoFiresFitted"),
-             error = function(e) print(e))
+                   filename = "ignitionNoFiresFitted")
   }
 
   convergence <- TRUE

--- a/fireSense_IgnitionFit.R
+++ b/fireSense_IgnitionFit.R
@@ -900,8 +900,12 @@ frequencyFitRun <- function(sim) {
     closeToBoundsOnlyCovariates <- closeToBounds[1:nx]
     # This only has terms with covariates (including pw in interaction), not pw terms on their own
     possTerms <- attr(terms, "term.labels")[1:nx]
-    toRemove <- do.call(rbind, lapply(ctb$term, function(trm) grepl(trm, possTerms)))
-    toRemove <- apply(toRemove, 2, any)
+    if (nrow(ctb)) {
+      toRemove <- do.call(rbind, lapply(ctb$term, function(trm) grepl(trm, possTerms)))
+      toRemove <- apply(toRemove, 2, any)
+    } else {
+      toRemove <- sapply(closeToBoundsOnlyCovariates, function(x) FALSE)
+    }
     toRemove <- toRemove | closeToBoundsOnlyCovariates
 
     possTerms <- possTerms[!toRemove]


### PR DESCRIPTION
* Rescaled variables were not being properly restored to their original scale
* Plots has an internal error after saving figures see Plots throws error when appending to sim@outputs SpaDES.core#204. A tryCatch was put in place to prevent failure

This is a revamp of PR #18, which for somereason I could not re-open